### PR TITLE
Add attributes to prevent CRLF conversion for test input files.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+* text=auto
+oadrtest/oadrtest/test_input/test_buffer1.txt text eol=crlf
+oadrtest/oadrtest/test_input/test_buffer2.txt text eol=crlf


### PR DESCRIPTION
Cloning the project on a Linux machine causes the two sample response files to incorrectly convert line endings, causing the tests to fail.  This patch adds a `.gitattributes` file which excludes those two particular files from automatic line conversion.